### PR TITLE
Add caching configuration attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ sensor:
     host: 192.168.100.100
 ```
 
-You can enable caching the power today value using the `cache_power_today` configuration attribute. See how does it work when you might need to use this.
+You can enable caching the power today value using the `cache_power_today` configuration attribute. You probably won't need this but check "How does it work?" when/why you might.
 
 ``` YAML
 sensor:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ sensor:
     host: 192.168.100.100
 ```
 
+You can enable caching the power today value using the `cache_power_today` configuration attribute. See how does it work when you might need to use this.
+
+``` YAML
+sensor:
+  - platform: omnik_inverter
+    host: 192.168.100.100
+    cache_power_today: true
+```
+
 ## How does it work?
 
 The web interface has a javascript file that contains the actual values. This is updated every minute (afaik). Check it out in your browser at `http://<your omnik ip address>/js/status.js`
@@ -58,7 +67,9 @@ This custom component basically requests the URL, looks for the _webData_ part a
 - `sensor.solar_power_today` (kWh)
 - `sensor.solar_power_total` (kWh)
 
-> Note: I ran into the problem that my Omnik inverter resets the `solar_power_today` to 0.0 after 21:00. This component therefor caches the value and only resets to 0.0 after midnight.
+### Caching power today.
+
+You might run into the problem that your Omnik inverter resets the `solar_power_today` to 0.0 after for example 21:00. By setting the `cache_power_today` config attribute to `true` this component will cache the the value and only resets to 0.0 after midnight.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ sensor:
     host: 192.168.100.100
 ```
 
-You can enable caching the power today value using the `cache_power_today` configuration attribute. You probably won't need this but check "How does it work?" when/why you might.
+By default caching the power today value is enabled, you can disable it using the `cache_power_today` configuration attribute. Check "How does it work?" when/why you might need to disable it.
 
 ``` YAML
 sensor:
   - platform: omnik_inverter
     host: 192.168.100.100
-    cache_power_today: true
+    cache_power_today: false
 ```
 
 ## How does it work?
@@ -69,7 +69,7 @@ This custom component basically requests the URL, looks for the _webData_ part a
 
 ### Caching power today.
 
-You might run into the problem that your Omnik inverter resets the `solar_power_today` to 0.0 after for example 21:00. By setting the `cache_power_today` config attribute to `true` this component will cache the the value and only resets to 0.0 after midnight.
+In a few cases the Omnik inverter resets the `solar_power_today` to 0.0 after for example 21:00. By setting the `cache_power_today` config attribute to `true` (default) this component will cache the the value and only resets to 0.0 after midnight. If you do not experience this, then disable the cache by setting the config variable to `false`.
 
 ## References
 

--- a/custom_components/omnik_inverter/sensor.py
+++ b/custom_components/omnik_inverter/sensor.py
@@ -4,7 +4,7 @@ configuration.yaml
 sensor:
   - platform: omnik_inverter
     host: 192.168.100.100
-    cache_power_today: false
+    cache_power_today: true
 """
 import logging
 from datetime import timedelta
@@ -23,7 +23,7 @@ from urllib.request import urlopen
 import re
 import pickle
 
-VERSION = '2.0.0'
+VERSION = '1.1.0'
 
 CONF_CACHE_POWER_TODAY = 'cache_power_today'
 
@@ -42,7 +42,7 @@ SENSOR_TYPES = {
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_CACHE_POWER_TODAY, default=False): cv.boolean
+    vol.Optional(CONF_CACHE_POWER_TODAY, default=True): cv.boolean
 })
 
 
@@ -161,13 +161,10 @@ class OmnikInverterSensor(Entity):
 
             # Check if caching is disabled
             if (self.cache == False):
-                _LOGGER.debug("Cache disabled, returning early.")
-
                 # Update the sensor state, divide by 100 to make it kWh
                 self._state = (nextValue / 100)
                 return
 
-            _LOGGER.debug("Cache enabled.")
             # Fetch data from the cache
             try:
                 cache = pickle.load(open(cacheName, 'rb'))


### PR DESCRIPTION
### What does it do?
This PR adds a configuration option called `cache_power_today`. This will, if set to true, enable the caching of the power today value until midnight and reset it at 00:00.

This is a breaking change because I disabled the caching by default, since it currently only affects my own system and I think in general caching won't be needed.

Could you please review this PR @gerard33?