### PR TITLE
Allow the usage of a custom entity_name

### DIFF
--- a/custom_components/omnik_inverter/manifest.json
+++ b/custom_components/omnik_inverter/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "omnik_inverter",
   "name": "Omnik Inverter",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "documentation": "https://github.com/robbinjanssen/home-assistant-omnik-inverter",
   "dependencies": [],
   "codeowners": [


### PR DESCRIPTION
For my application I have multiple omnik inverters and needed to set the name per convert in order for the sensors not to override eachother