### PR TITLE
Fix capital P in password key

### DIFF
--- a/custom_components/omnik_inverter/translations/en.json
+++ b/custom_components/omnik_inverter/translations/en.json
@@ -16,7 +16,7 @@
                     "name": "Name",
                     "host": "Host",
                     "username": "Username",
-                    "Password": "Password"
+                    "password": "Password"
                 }
             },
             "user": {


### PR DESCRIPTION
The "Password" string was not showing in ConfigFlow UI for EN language due to the key being wrong.