### PR TITLE
Do not overwrite OmnikInverter after setting up for html

### DIFF
--- a/custom_components/omnik_inverter/__init__.py
+++ b/custom_components/omnik_inverter/__init__.py
@@ -104,11 +104,12 @@ class OmnikInverterDataUpdateCoordinator(DataUpdateCoordinator[OmnikInverterData
                 password=self.config_entry.data[CONF_PASSWORD],
                 session=async_get_clientsession(hass),
             )
-        self.omnikinverter = OmnikInverter(
-            host=self.config_entry.data[CONF_HOST],
-            source_type=self.config_entry.data[CONF_SOURCE_TYPE],
-            session=async_get_clientsession(hass),
-        )
+        else:
+          self.omnikinverter = OmnikInverter(
+              host=self.config_entry.data[CONF_HOST],
+              source_type=self.config_entry.data[CONF_SOURCE_TYPE],
+              session=async_get_clientsession(hass),
+          )
 
     async def _async_update_data(self) -> OmnikInverterData:
         """Fetch data from Omnik Inverter."""


### PR DESCRIPTION
I tried this component with my wifistick which has HTML source and needs username/password.

I noticed that setting up with the ConfigFlow worked fine, but later updates would not work. It turns out the OmnikInverter that is setup for HTML source gets overwritten. This change fixes that.

It is running fine for me now with this change, it should still work for the other sources.