### PR TITLE
Ginlong Solis wifistick

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It has been tested and developed on the following inverters:
 - Omnik2500TL (HTML)
 - Omnik2000TL2 (JSON)
 - Omnik4000TL2
-- Ginlong stick (JSON)
+- Ginlong stick (JSON and HTML)
 - Ginlong stick (HTML)
 - Hosola 1500TL
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ It has been tested and developed on the following inverters:
 - Omnik2000TL2 (JSON)
 - Omnik4000TL2
 - Ginlong stick (JSON and HTML)
-- Ginlong stick (HTML)
 - Hosola 1500TL
 
 After installation you can add the inverter through the integration page. The values will be presented by two devices in Home Assistant. One is the inverter containing the actual solar power, and one is the device containing information about the wifi signal.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ It has been tested and developed on the following inverters:
 - Omnik2000TL2 (JSON)
 - Omnik4000TL2
 - Ginlong stick (JSON)
+- Ginlong stick (HTML)
 - Hosola 1500TL
 
 After installation you can add the inverter through the integration page. The values will be presented by two devices in Home Assistant. One is the inverter containing the actual solar power, and one is the device containing information about the wifi signal.

--- a/custom_components/omnik_inverter/__init__.py
+++ b/custom_components/omnik_inverter/__init__.py
@@ -39,7 +39,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         await coordinator.async_config_entry_first_refresh()
     except ConfigEntryNotReady:
-        await coordinator.omnikinverter.close()
         raise
 
     hass.data.setdefault(DOMAIN, {})
@@ -55,7 +54,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         coordinator = hass.data[DOMAIN].pop(entry.entry_id)
-        await coordinator.omnikinverter.close()
 
     return unload_ok
 
@@ -107,14 +105,12 @@ class OmnikInverterDataUpdateCoordinator(DataUpdateCoordinator[OmnikInverterData
                 source_type=self.config_entry.data[CONF_SOURCE_TYPE],
                 username=self.config_entry.data[CONF_USERNAME],
                 password=self.config_entry.data[CONF_PASSWORD],
-                session=async_get_clientsession(hass),
             )
         else:
-            self.omnikinverter = OmnikInverter(
-                host=self.config_entry.data[CONF_HOST],
-                source_type=self.config_entry.data[CONF_SOURCE_TYPE],
-                session=async_get_clientsession(hass),
-            )
+          self.omnikinverter = OmnikInverter(
+              host=self.config_entry.data[CONF_HOST],
+              source_type=self.config_entry.data[CONF_SOURCE_TYPE],
+          )
 
     async def _async_update_data(self) -> OmnikInverterData:
         """Fetch data from Omnik Inverter."""

--- a/custom_components/omnik_inverter/__init__.py
+++ b/custom_components/omnik_inverter/__init__.py
@@ -12,7 +12,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -107,10 +106,10 @@ class OmnikInverterDataUpdateCoordinator(DataUpdateCoordinator[OmnikInverterData
                 password=self.config_entry.data[CONF_PASSWORD],
             )
         else:
-          self.omnikinverter = OmnikInverter(
-              host=self.config_entry.data[CONF_HOST],
-              source_type=self.config_entry.data[CONF_SOURCE_TYPE],
-          )
+            self.omnikinverter = OmnikInverter(
+                host=self.config_entry.data[CONF_HOST],
+                source_type=self.config_entry.data[CONF_SOURCE_TYPE],
+            )
 
     async def _async_update_data(self) -> OmnikInverterData:
         """Fetch data from Omnik Inverter."""

--- a/custom_components/omnik_inverter/config_flow.py
+++ b/custom_components/omnik_inverter/config_flow.py
@@ -16,7 +16,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
     CONF_SCAN_INTERVAL,
@@ -69,7 +68,6 @@ class OmnikInverterFlowHandler(ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            session = async_get_clientsession(self.hass)
             try:
                 async with OmnikInverter(
                     host=user_input[CONF_HOST],
@@ -107,7 +105,6 @@ class OmnikInverterFlowHandler(ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            session = async_get_clientsession(self.hass)
             try:
                 async with OmnikInverter(
                     host=user_input[CONF_HOST],

--- a/custom_components/omnik_inverter/config_flow.py
+++ b/custom_components/omnik_inverter/config_flow.py
@@ -74,7 +74,6 @@ class OmnikInverterFlowHandler(ConfigFlow, domain=DOMAIN):
                 async with OmnikInverter(
                     host=user_input[CONF_HOST],
                     source_type=self.source_type,
-                    session=session,
                 ) as client:
                     await client.inverter()
             except OmnikInverterError:
@@ -115,7 +114,6 @@ class OmnikInverterFlowHandler(ConfigFlow, domain=DOMAIN):
                     source_type=self.source_type,
                     username=user_input[CONF_USERNAME],
                     password=user_input[CONF_PASSWORD],
-                    session=session,
                 ) as client:
                     await client.inverter()
             except OmnikInverterError:

--- a/custom_components/omnik_inverter/manifest.json
+++ b/custom_components/omnik_inverter/manifest.json
@@ -9,6 +9,6 @@
     "@robbinjanssen",
     "@klaasnicolaas"
   ],
-  "requirements": ["omnikinverter==0.6.1"],
+  "requirements": ["git+https://github.com/mvdwetering/python-omnikinverter.git@solis_wifistick#omnikinverter==0.0.0"],
   "iot_class": "local_polling"
 }

--- a/custom_components/omnik_inverter/manifest.json
+++ b/custom_components/omnik_inverter/manifest.json
@@ -9,6 +9,6 @@
     "@robbinjanssen",
     "@klaasnicolaas"
   ],
-  "requirements": ["git+https://github.com/mvdwetering/python-omnikinverter.git@solis_wifistick#omnikinverter==0.0.0"],
+  "requirements": ["omnikinverter==0.7.0"],
   "iot_class": "local_polling"
 }


### PR DESCRIPTION
I made some changes to the python lib to make it work with the wifistick I have on my Ginlong Solis inverter. It is basically the HTML version, but the stick does not properly support sessions :( . 
See PR https://github.com/klaasnicolaas/python-omnikinverter/pull/55

Unfortunately that will result in a breaking API change on the lib.

As requested by @klaasnicolaas I make this pullrequest that updates the custom_component to take these changes into account.

Note that the manifest.json now points to my branch of the python lib so I could use it for testing locally and since there is no release yet of the python lib I would not know where to point it otherwise. So that still needs updating.