### PR TITLE
Add diagnostics to integration

### DIFF
--- a/custom_components/omnik_inverter/diagnostics.py
+++ b/custom_components/omnik_inverter/diagnostics.py
@@ -1,0 +1,34 @@
+"""Diagnostics support for Omnik Inverter integration."""
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_IP_ADDRESS
+from homeassistant.core import HomeAssistant
+
+from . import OmnikInverterDataUpdateCoordinator
+from .const import DOMAIN, SERVICE_DEVICE, SERVICE_INVERTER
+
+TO_REDACT = {CONF_HOST, CONF_IP_ADDRESS}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator: OmnikInverterDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    return {
+        "entry": {
+            "title": entry.title,
+            "data": async_redact_data(entry.data, TO_REDACT),
+            "options": async_redact_data(entry.options, TO_REDACT),
+        },
+        "data": {
+            "device": asdict(coordinator.data[SERVICE_DEVICE]),
+            "inverter": asdict(coordinator.data[SERVICE_INVERTER]),
+        },
+    }


### PR DESCRIPTION
From [Home Assistant version 2022.2](https://rc--home-assistant-docs.netlify.app/blog/2022/01/25/release-20222/#diagnostics-for-integration--device) it is possible to download diagnostics information from the integration, useful for developers to debug, for example. Maybe make it clear somewhere that when you create an issue you should include this diagnostics overview?