### PR TITLE
Add Omnik3000TL and Bosswerk MI600 to the supported models

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,13 @@ It has been tested and developed on the following inverters:
 - Omnik1000TL
 - Omnik1500TL
 - Omnik2000TL
-- Omnik2500TL (HTML)
 - Omnik2000TL2 (JSON)
+- Omnik2500TL (HTML)
+- Omnik3000TL
 - Omnik4000TL2
 - Ginlong stick (JSON and HTML)
 - Hosola 1500TL
+- Bosswerk MI600 (HTML)
 
 After installation you can add the inverter through the integration page. The values will be presented by two devices in Home Assistant. One is the inverter containing the actual solar power, and one is the device containing information about the wifi signal.
 

--- a/README.md
+++ b/README.md
@@ -13,16 +13,18 @@ It has been tested and developed on the following inverters:
 
 ## Supported models
 
-- Omnik1000TL
-- Omnik1500TL
-- Omnik2000TL
-- Omnik2000TL2 (JSON)
-- Omnik2500TL (HTML)
-- Omnik3000TL
-- Omnik4000TL2
-- Ginlong stick (JSON and HTML)
-- Hosola 1500TL
-- Bosswerk MI600 (HTML)
+| Brand    | Model            | Datasource |
+|----------|------------------|------------|
+| Omnik    | Omniksol 1000TL  | JS         |
+| Omnik    | Omniksol 1500TL  | JS         |
+| Omnik    | Omniksol 2000TL  | JS         |
+| Omnik    | Omniksol 2000TL2 | JSON       |
+| Omnik    | Omniksol 2500TL  | HTML       |
+| Omnik    | Omniksol 3000TL  | JS         |
+| Omnik    | Omniksol 4000TL2 | JS         |
+| Ginlong  | Solis-DLS-WiFi   | JSON/HTML  |
+| Hosola   | 1500TL           | JS         |
+| Bosswerk | BW-MI600         | HTML       |
 
 After installation you can add the inverter through the integration page. The values will be presented by two devices in Home Assistant. One is the inverter containing the actual solar power, and one is the device containing information about the wifi signal.
 


### PR DESCRIPTION
Both [Omnik3000TL](https://github.com/robbinjanssen/home-assistant-omnik-inverter/discussions/98) and [Bosswerk MI600](https://github.com/robbinjanssen/home-assistant-omnik-inverter/issues/96) have been confirmed as working models with this component :-)