### PR TITLE
Add setup steps for new python-omnikinverter TCP source to config flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It has been tested and developed on the following inverters:
 | Omnik    | Omniksol 2000TL  | JS         |
 | Omnik    | Omniksol 2000TL2 | JSON       |
 | Omnik    | Omniksol 2500TL  | HTML       |
-| Omnik    | Omniksol 3000TL  | JS         |
+| Omnik    | Omniksol 3000TL  | TCP        |
 | Omnik    | Omniksol 4000TL2 | JS         |
 | Ginlong  | Solis-DLS-WiFi   | JSON/HTML  |
 | Hosola   | 1500TL           | JS         |
@@ -62,7 +62,7 @@ custom_components
 
 [![ha_badge][ha-add-shield]][ha-add-url]
 
-To configure the component, add it using [Home Assistant integrations][ha-add-url]. This will provide you with a configuration screen where you can first select the data source. Again, most inverters use JS. Some use JSON and in some rare cases HTML is used.
+To configure the component, add it using [Home Assistant integrations][ha-add-url]. This will provide you with a configuration screen where you can first select the data source. Again, most inverters use JS. Some use JSON and in some rare cases HTML is used. The TCP backend contains additional electrical statistics but lacks information about the WiFi module.
 
 After selecting the data source, enter a name and IP address as host and you're good to go!
 
@@ -84,7 +84,7 @@ The web interface has a javascript, JSON or HTML file that contains the actual v
 
 - Most inverters have a JS file, try accessing `http://<your omnik ip address>/js/status.js` in your browser.
 - Some inverters use a JSON status file to output the values. Check if your inverter outputs JSON data by navigating to: `http://<your omnik ip address>/status.json?CMD=inv_query`.
-- A few inverters dont have JS or JSON but output the values directly in a HTML files. Check if your inverter supports the following URL: `http://<your omnik ip address>/status.html`. _Note that this will work for almost all inverters, but you need to check the HTML source for a `<script>` tag that contains the relevant `webData`._
+- A few inverters don't have JS or JSON but output the values directly in a HTML files. Check if your inverter supports the following URL: `http://<your omnik ip address>/status.html`. _Note that this will work for almost all inverters, but you need to check the HTML source for a `<script>` tag that contains the relevant `webData`._
 
 If none of the methods work, please open a [new issue](https://github.com/robbinjanssen/home-assistant-omnik-inverter/issues/new) and we might be able to make it work for your inverter 😄 Make sure you let us know what inverter you use.
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ It has been tested and developed on the following inverters:
 | Omnik    | Omniksol 2000TL  | JS         |
 | Omnik    | Omniksol 2000TL2 | JSON       |
 | Omnik    | Omniksol 2500TL  | HTML       |
-| Omnik    | Omniksol 3000TL  | TCP        |
+| Omnik    | Omniksol 3000TL  | JS/TCP     |
 | Omnik    | Omniksol 4000TL2 | JS         |
 | Ginlong  | Solis-DLS-WiFi   | JSON/HTML  |
 | Hosola   | 1500TL           | JS         |

--- a/custom_components/omnik_inverter/__init__.py
+++ b/custom_components/omnik_inverter/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import (
     CONF_SCAN_INTERVAL,
+    CONF_SERIAL,
     CONF_SOURCE_TYPE,
     CONFIGFLOW_VERSION,
     DEFAULT_SCAN_INTERVAL,
@@ -104,6 +105,12 @@ class OmnikInverterDataUpdateCoordinator(DataUpdateCoordinator[OmnikInverterData
                 source_type=self.config_entry.data[CONF_SOURCE_TYPE],
                 username=self.config_entry.data[CONF_USERNAME],
                 password=self.config_entry.data[CONF_PASSWORD],
+            )
+        if self.config_entry.data[CONF_SOURCE_TYPE] == "tcp":
+            self.omnikinverter = OmnikInverter(
+                host=self.config_entry.data[CONF_HOST],
+                source_type=self.config_entry.data[CONF_SOURCE_TYPE],
+                serial_number=self.config_entry.data[CONF_SERIAL],
             )
         else:
             self.omnikinverter = OmnikInverter(

--- a/custom_components/omnik_inverter/config_flow.py
+++ b/custom_components/omnik_inverter/config_flow.py
@@ -20,6 +20,7 @@ from homeassistant.data_entry_flow import FlowResult
 from .const import (
     CONF_SCAN_INTERVAL,
     CONF_SOURCE_TYPE,
+    CONF_SERIAL,
     CONFIGFLOW_VERSION,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
@@ -54,9 +55,11 @@ class OmnikInverterFlowHandler(ConfigFlow, domain=DOMAIN):
             self.source_type = user_selection.lower()
             if user_selection == "HTML":
                 return await self.async_step_setup_html()
+            elif user_selection == "TCP":
+                return await self.async_step_setup_tcp()
             return await self.async_step_setup()
 
-        list_of_types = ["Javascript", "JSON", "HTML"]
+        list_of_types = ["Javascript", "JSON", "HTML", "TCP"]
 
         schema = vol.Schema({vol.Required(CONF_TYPE): vol.In(list_of_types)})
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
@@ -136,6 +139,46 @@ class OmnikInverterFlowHandler(ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_HOST): str,
                     vol.Required(CONF_USERNAME): str,
                     vol.Required(CONF_PASSWORD): str,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_setup_tcp(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle setup flow for tcp route."""
+        errors = {}
+
+        if user_input is not None:
+            try:
+                async with OmnikInverter(
+                    host=user_input[CONF_HOST],
+                    source_type=self.source_type,
+                    serial_number=user_input[CONF_SERIAL],
+                ) as client:
+                    await client.inverter()
+            except OmnikInverterError:
+                errors["base"] = "cannot_connect"
+            else:
+                return self.async_create_entry(
+                    title=user_input[CONF_NAME],
+                    data={
+                        CONF_HOST: user_input[CONF_HOST],
+                        CONF_SOURCE_TYPE: self.source_type,
+                        CONF_SERIAL: user_input[CONF_SERIAL],
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="setup_tcp",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_NAME, default=self.hass.config.location_name
+                    ): str,
+                    vol.Required(CONF_HOST): str,
+                    vol.Required(CONF_SERIAL): int,
                 }
             ),
             errors=errors,

--- a/custom_components/omnik_inverter/config_flow.py
+++ b/custom_components/omnik_inverter/config_flow.py
@@ -147,7 +147,7 @@ class OmnikInverterFlowHandler(ConfigFlow, domain=DOMAIN):
     async def async_step_setup_tcp(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle setup flow for tcp route."""
+        """Handle setup flow for TCP route."""
         errors = {}
 
         if user_input is not None:

--- a/custom_components/omnik_inverter/const.py
+++ b/custom_components/omnik_inverter/const.py
@@ -12,6 +12,7 @@ DEFAULT_SCAN_INTERVAL = 4
 
 CONF_SOURCE_TYPE = "source_type"
 CONF_SCAN_INTERVAL = "scan_interval"
+CONF_SERIAL = "serial"
 
 ATTR_ENTRY_TYPE: Final = "entry_type"
 ENTRY_TYPE_SERVICE: Final = "service"

--- a/custom_components/omnik_inverter/diagnostics.py
+++ b/custom_components/omnik_inverter/diagnostics.py
@@ -10,9 +10,9 @@ from homeassistant.const import CONF_HOST, CONF_IP_ADDRESS
 from homeassistant.core import HomeAssistant
 
 from . import OmnikInverterDataUpdateCoordinator
-from .const import DOMAIN, SERVICE_DEVICE, SERVICE_INVERTER
+from .const import CONF_SERIAL, DOMAIN, SERVICE_DEVICE, SERVICE_INVERTER
 
-TO_REDACT = {CONF_HOST, CONF_IP_ADDRESS}
+TO_REDACT = {CONF_HOST, CONF_IP_ADDRESS, CONF_SERIAL}
 
 
 async def async_get_config_entry_diagnostics(

--- a/custom_components/omnik_inverter/manifest.json
+++ b/custom_components/omnik_inverter/manifest.json
@@ -9,6 +9,6 @@
     "@robbinjanssen",
     "@klaasnicolaas"
   ],
-  "requirements": ["omnikinverter==0.7.0"],
+  "requirements": ["git+https://github.com/MarijnS95/python-omnikinverter@tcp#omnikinverter==0.8.0"],
   "iot_class": "local_polling"
 }

--- a/custom_components/omnik_inverter/manifest.json
+++ b/custom_components/omnik_inverter/manifest.json
@@ -9,6 +9,6 @@
     "@robbinjanssen",
     "@klaasnicolaas"
   ],
-  "requirements": ["git+https://github.com/MarijnS95/python-omnikinverter@tcp#omnikinverter==0.8.0"],
+  "requirements": ["omnikinverter==0.8.0"],
   "iot_class": "local_polling"
 }

--- a/custom_components/omnik_inverter/translations/en.json
+++ b/custom_components/omnik_inverter/translations/en.json
@@ -19,6 +19,15 @@
                     "password": "Password"
                 }
             },
+            "setup_tcp": {
+                "title": "Omnik Inverter - TCP",
+                "description": "Set up Omnik Inverter to integrate with Home Assistant.",
+                "data": {
+                    "name": "Name",
+                    "host": "Host",
+                    "serial": "Serial Number"
+                }
+            },
             "user": {
                 "description": "Choose which data source applies to your Omnik Inverter.",
                 "data": {

--- a/custom_components/omnik_inverter/translations/nl.json
+++ b/custom_components/omnik_inverter/translations/nl.json
@@ -19,6 +19,15 @@
                     "password": "Wachtwoord"
                 }
             },
+            "setup_tcp": {
+                "title": "Omnik Inverter - TCP",
+                "description": "Stel Omnik Inverter in om te integreren met Home Assistant.",
+                "data": {
+                    "name": "Naam",
+                    "host": "Host",
+                    "serial": "Serienummer",
+                }
+            },
             "user": {
                 "description": "Kies welke data source van toepassing is bij jouw Omnik Inverter.",
                 "data": {

--- a/custom_components/omnik_inverter/translations/nl.json
+++ b/custom_components/omnik_inverter/translations/nl.json
@@ -25,7 +25,7 @@
                 "data": {
                     "name": "Naam",
                     "host": "Host",
-                    "serial": "Serienummer",
+                    "serial": "Serienummer"
                 }
             },
             "user": {


### PR DESCRIPTION
[#134] introduces a TCP connection backend to the `python-omnikinverter` package, whch is "lower" in overhead when gathering data from the inverter while at the same time providing more statistics.  Entities for these additional statistics - as well as some that are currently missing
- will be added in a separate PR.  Note that device information (firmware, IP address and WiFi signal strength) is unavailable through this API.

[#134]: https://github.com/klaasnicolaas/python-omnikinverter/pull/134

# TODO:

Feedback welcome on these - most can probably be postponed to followup PRs to keep this simple to review:

- Users now need to retrieve the serial number from their device. This value is trivially provided as `var m2mMid="..."` from the JS backend. We can automate the retrieval for this and/or perform both requests at the same time, see the next option;
- > Note that device information (firmware, IP address and WiFi signal strength) is unavailable through this API.
  Regarding this: The current implementation already performs two requests every time: one in `.device()` and one in `.inverter()`. We can perhaps combine these in such a way that `.device()` retrieves the "missing" data through JS (including the S/N for the TCP connection) and `.inverter()` uses TCP to read all statistics;
- Separate PR to add all the new entities - the TCP backend provides information for 3 input (strings) and 3 output channels which we'd probably like to not even create an entity for if they're unknown/unset (don't exist)?;
- After some testing: recommend the TCP backend (as above: possibly in conjunction with JS) instead of JS/HTML.
