### PR TITLE
sensor: Emit entities for new fields from the TCP backend

### DIFF
--- a/custom_components/omnik_inverter/sensor.py
+++ b/custom_components/omnik_inverter/sensor.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 import dataclasses
 
-import logging
 from typing import Literal
 
 from homeassistant.components.sensor import (
@@ -33,9 +32,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import OmnikInverterDataUpdateCoordinator
 from .const import DOMAIN, MANUFACTURER, SERVICE_DEVICE, SERVICE_INVERTER, SERVICES
-
-
-_LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -75,7 +71,6 @@ SENSORS: dict[Literal["inverter", "device"], tuple[SensorEntityDescription, ...]
             name="Solar Production - Uptime",
             icon="mdi:clock",
             native_unit_of_measurement=TIME_HOURS,
-            device_class=None,
             state_class=SensorStateClass.TOTAL_INCREASING,
         ),
         SensorEntityDescription(
@@ -286,4 +281,5 @@ class OmnikInverterArraySensorEntity(OmnikInverterSensorEntity):
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         value = getattr(self.coordinator.data[self._service_key], self.data_key)
-        return value[self.index]
+        if value is not None:
+            return value[self.index]

--- a/custom_components/omnik_inverter/sensor.py
+++ b/custom_components/omnik_inverter/sensor.py
@@ -39,8 +39,6 @@ class ArraySensorEntityDescription(SensorEntityDescription):
     range: range | None = None
     data_key: str | None = None
 
-
-entity_registry_enabled_default = (False,)
 SENSORS: dict[Literal["inverter", "device"], tuple[SensorEntityDescription, ...]] = {
     SERVICE_INVERTER: (
         SensorEntityDescription(

--- a/custom_components/omnik_inverter/sensor.py
+++ b/custom_components/omnik_inverter/sensor.py
@@ -1,6 +1,9 @@
 """Support for Omnik Inverter sensors."""
 from __future__ import annotations
+from dataclasses import dataclass
+import dataclasses
 
+import logging
 from typing import Literal
 
 from homeassistant.components.sensor import (
@@ -11,7 +14,16 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ENERGY_KILO_WATT_HOUR, PERCENTAGE, POWER_WATT
+from homeassistant.const import (
+    ELECTRIC_CURRENT_AMPERE,
+    ELECTRIC_POTENTIAL_VOLT,
+    ENERGY_KILO_WATT_HOUR,
+    PERCENTAGE,
+    POWER_WATT,
+    TEMP_CELSIUS,
+    FREQUENCY_HERTZ,
+    TIME_HOURS,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
@@ -22,6 +34,17 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from . import OmnikInverterDataUpdateCoordinator
 from .const import DOMAIN, MANUFACTURER, SERVICE_DEVICE, SERVICE_INVERTER, SERVICES
 
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class ArraySensorEntityDescription(SensorEntityDescription):
+    range: range | None = None
+    data_key: str | None = None
+
+
+entity_registry_enabled_default = (False,)
 SENSORS: dict[Literal["inverter", "device"], tuple[SensorEntityDescription, ...]] = {
     SERVICE_INVERTER: (
         SensorEntityDescription(
@@ -47,6 +70,88 @@ SENSORS: dict[Literal["inverter", "device"], tuple[SensorEntityDescription, ...]
             device_class=SensorDeviceClass.ENERGY,
             state_class=SensorStateClass.TOTAL_INCREASING,
         ),
+        SensorEntityDescription(
+            key="solar_hours_total",
+            name="Solar Production - Uptime",
+            icon="mdi:clock",
+            native_unit_of_measurement=TIME_HOURS,
+            device_class=None,
+            state_class=SensorStateClass.TOTAL_INCREASING,
+        ),
+        SensorEntityDescription(
+            key="temperature",
+            name="Inverter temperature",
+            icon="mdi:thermometer",
+            native_unit_of_measurement=TEMP_CELSIUS,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        ArraySensorEntityDescription(
+            key="dc_input_{}_voltage",
+            data_key="dc_input_voltage",
+            range=range(3),
+            name="DC Input {} - Voltage",
+            entity_registry_enabled_default=False,
+            icon="mdi:lightning-bolt",
+            native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
+            device_class=SensorDeviceClass.VOLTAGE,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        ArraySensorEntityDescription(
+            key="dc_input_{}_current",
+            data_key="dc_input_current",
+            range=range(3),
+            name="DC Input {} - Current",
+            entity_registry_enabled_default=False,
+            icon="mdi:current-dc",
+            native_unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
+            device_class=SensorDeviceClass.CURRENT,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        ArraySensorEntityDescription(
+            key="ac_output_{}_voltage",
+            data_key="ac_output_voltage",
+            range=range(3),
+            name="AC Output {} - Voltage",
+            entity_registry_enabled_default=False,
+            icon="mdi:lightning-bolt",
+            native_unit_of_measurement=ELECTRIC_POTENTIAL_VOLT,
+            device_class=SensorDeviceClass.VOLTAGE,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        ArraySensorEntityDescription(
+            key="ac_output_{}_current",
+            data_key="ac_output_current",
+            range=range(3),
+            name="AC Output {} - Current",
+            entity_registry_enabled_default=False,
+            icon="mdi:current-ac",
+            native_unit_of_measurement=ELECTRIC_CURRENT_AMPERE,
+            device_class=SensorDeviceClass.CURRENT,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        ArraySensorEntityDescription(
+            key="ac_output_{}_power",
+            data_key="ac_output_power",
+            range=range(3),
+            name="AC Output {} - Power",
+            entity_registry_enabled_default=False,
+            icon="mdi:lightning-bolt",
+            native_unit_of_measurement=POWER_WATT,
+            device_class=SensorDeviceClass.POWER,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        ArraySensorEntityDescription(
+            key="ac_output_{}_frequency",
+            data_key="ac_output_frequency",
+            range=range(3),
+            name="AC Output {} - Frequency",
+            entity_registry_enabled_default=False,
+            icon="mdi:sine-wave",
+            native_unit_of_measurement=FREQUENCY_HERTZ,
+            device_class=SensorDeviceClass.FREQUENCY,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
     ),
     SERVICE_DEVICE: (
         SensorEntityDescription(
@@ -70,16 +175,32 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up Omnik Inverter Sensors based on a config entry."""
+
+    def create_sensor_entities(description, service_key):
+        if isinstance(description, ArraySensorEntityDescription):
+            for i in description.range:
+                yield OmnikInverterArraySensorEntity(
+                    coordinator=hass.data[DOMAIN][entry.entry_id],
+                    index=i,
+                    description=description,
+                    service_key=service_key,
+                    name=entry.title,
+                    service=SERVICES[service_key],
+                )
+        else:
+            yield OmnikInverterSensorEntity(
+                coordinator=hass.data[DOMAIN][entry.entry_id],
+                description=description,
+                service_key=service_key,
+                name=entry.title,
+                service=SERVICES[service_key],
+            )
+
     async_add_entities(
-        OmnikInverterSensorEntity(
-            coordinator=hass.data[DOMAIN][entry.entry_id],
-            description=description,
-            service_key=service_key,
-            name=entry.title,
-            service=SERVICES[service_key],
-        )
+        sensor_entity
         for service_key, service_sensors in SENSORS.items()
         for description in service_sensors
+        for sensor_entity in create_sensor_entities(description, service_key)
     )
 
 
@@ -128,3 +249,41 @@ class OmnikInverterSensorEntity(CoordinatorEntity, SensorEntity):
         if isinstance(value, str):
             return value.lower()
         return value
+
+
+class OmnikInverterArraySensorEntity(OmnikInverterSensorEntity):
+    """Defines an Omnik Inverter sensor reading from an array."""
+
+    def __init__(
+        self,
+        *,
+        coordinator: OmnikInverterDataUpdateCoordinator,
+        index: int,
+        description: ArraySensorEntityDescription,
+        service_key: Literal["inverter", "device"],
+        name: str,
+        service: str,
+    ) -> None:
+        self.index = index
+        self.data_key = description.data_key
+        human_index = index + 1
+
+        description = dataclasses.replace(
+            description,
+            key=description.key.format(human_index),
+            name=description.name.format(human_index),
+        )
+
+        super().__init__(
+            coordinator=coordinator,
+            description=description,
+            service_key=service_key,
+            name=name,
+            service=service,
+        )
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the state of the sensor."""
+        value = getattr(self.coordinator.data[self._service_key], self.data_key)
+        return value[self.index]


### PR DESCRIPTION
The [TCP backend in python-omnikinverter] emits, in addition to existing fields (but without any info on the WiFi "Device"):
- Inverter temparature;
- Total hours of inverter uptime;
- Voltage and current of a total of 3 DC input strings;
- Voltage, current, frequency and power for AC output (also 3...).

[TCP backend in python-omnikinverter]: https://github.com/klaasnicolaas/python-omnikinverter/pull/134

This requires new types here as the DC input and AC output values are provided in arrays.
