### PR TITLE
Prevent overwriting `omnikinverter` with authentication-less instance on "html" source type

### DIFF
--- a/custom_components/omnik_inverter/__init__.py
+++ b/custom_components/omnik_inverter/__init__.py
@@ -106,7 +106,7 @@ class OmnikInverterDataUpdateCoordinator(DataUpdateCoordinator[OmnikInverterData
                 username=self.config_entry.data[CONF_USERNAME],
                 password=self.config_entry.data[CONF_PASSWORD],
             )
-        if self.config_entry.data[CONF_SOURCE_TYPE] == "tcp":
+        elif self.config_entry.data[CONF_SOURCE_TYPE] == "tcp":
             self.omnikinverter = OmnikInverter(
                 host=self.config_entry.data[CONF_HOST],
                 source_type=self.config_entry.data[CONF_SOURCE_TYPE],


### PR DESCRIPTION
Fixes #112, fixes #113

This should have been an `elif`, now causing `source_type = "html"` to fall into the `else` branch of the check for `"tcp"` and creating an `OmnikInverter` instance without username and password.
