### PR TITLE
Reuse unique names from previous version

### DIFF
--- a/custom_components/omnik_inverter/manifest.json
+++ b/custom_components/omnik_inverter/manifest.json
@@ -2,7 +2,7 @@
   "domain": "omnik_inverter",
   "name": "Omnik Inverter",
   "config_flow": true,
-  "version": "2.4.0",
+  "version": "2.5.1",
   "documentation": "https://github.com/robbinjanssen/home-assistant-omnik-inverter",
   "issue_tracker": "https://github.com/robbinjanssen/home-assistant-omnik-inverter/issues",
   "codeowners": [

--- a/custom_components/omnik_inverter/models.py
+++ b/custom_components/omnik_inverter/models.py
@@ -20,6 +20,7 @@ class OmnikInverterEntity(
     _name: str
     coordinator: OmnikInverterDataUpdateCoordinator
     service: str
+    entry_id: str
 
     def __init__(
         self,
@@ -39,6 +40,7 @@ class OmnikInverterEntity(
         self._name = name
         self.coordinator = coordinator
         self.service = service
+        self.entry_id = coordinator.config_entry.entry_id
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -50,7 +52,7 @@ class OmnikInverterEntity(
             to the correct device.
         """
         return DeviceInfo(
-            identifiers={(DOMAIN, f"{self._name}_{self.service}")},
+            identifiers={(DOMAIN, f"{self.entry_id}_{self.service}")},
             name=self.service.title(),
             manufacturer=MANUFACTURER,
             entry_type=DeviceEntryType.SERVICE,

--- a/custom_components/omnik_inverter/sensor.py
+++ b/custom_components/omnik_inverter/sensor.py
@@ -239,7 +239,9 @@ class OmnikInverterSensor(OmnikInverterEntity, SensorEntity):
         self.entity_id = (
             f"{SENSOR_DOMAIN}.{self._name}_{self.entity_description.key}"  # noqa: E501
         )
-        self._attr_unique_id = f"{self._name}_{service}_{self.entity_description.key}"
+        self._attr_unique_id = (
+            f"{self.entry_id}_{service}_{self.entity_description.key}"
+        )
         self._attr_name = self.entity_description.name
 
     @property


### PR DESCRIPTION
### What does it do?
Reuse the naming for entity_ids like it was done in v2.4.2


Closes #153 