### PR TITLE
config_flow: Print exception info to log

### DIFF
--- a/custom_components/omnik_inverter/config_flow.py
+++ b/custom_components/omnik_inverter/config_flow.py
@@ -25,6 +25,7 @@ from .const import (
     CONFIGFLOW_VERSION,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    LOGGER,
 )
 
 
@@ -128,6 +129,7 @@ class OmnikInverterFlowHandler(ConfigFlow, domain=DOMAIN):
                 ) as client:
                     await client.inverter()
             except OmnikInverterError:
+                LOGGER.exception("Failed to connect to the Omnik")
                 errors["base"] = "cannot_connect"
             except Exception as error:  # pylint: disable=broad-exception-caught
                 errors["base"] = str(error)
@@ -178,6 +180,7 @@ class OmnikInverterFlowHandler(ConfigFlow, domain=DOMAIN):
                 ) as client:
                     await client.inverter()
             except OmnikInverterError:
+                LOGGER.exception("Failed to connect to the Omnik")
                 errors["base"] = "cannot_connect"
             except Exception as error:  # pylint: disable=broad-exception-caught
                 errors["base"] = str(error)
@@ -231,6 +234,7 @@ class OmnikInverterFlowHandler(ConfigFlow, domain=DOMAIN):
                 ) as client:
                     await client.inverter()
             except OmnikInverterError:
+                LOGGER.exception("Failed to connect to the Omnik")
                 errors["base"] = "cannot_connect"
             except Exception as error:  # pylint: disable=broad-except
                 errors["base"] = str(error)

--- a/custom_components/omnik_inverter/coordinator.py
+++ b/custom_components/omnik_inverter/coordinator.py
@@ -94,7 +94,9 @@ class OmnikInverterDataUpdateCoordinator(DataUpdateCoordinator):
             }
             return data
         except OmnikInverterAuthError as error:
+            _LOGGER.exception("Failed to authenticate with the Omnik")
             raise ConfigEntryAuthFailed from error
 
-        except OmnikInverterError as err:
-            raise UpdateFailed(err) from err
+        except OmnikInverterError as error:
+            _LOGGER.exception("Failed to connect to the Omnik")
+            raise UpdateFailed(error) from error


### PR DESCRIPTION
We currently consume every `OmnikInverterError` and only raise a `cannot_connect` error to the UI, with no context whatsoever.  It could be a connection error, but also a message that fails to parse/verify.  Print the stacktrace to the log so that we can better aid our users when they encounter issues; this also makes it easier to understand and solve compatibility problems with other brands that use a very similar yet not identical message format.
