### PR TITLE
Fix `CONF_SERIAL` type in options flow to be `int` instead of `str`

### DIFF
--- a/custom_components/omnik_inverter/config_flow.py
+++ b/custom_components/omnik_inverter/config_flow.py
@@ -347,7 +347,7 @@ class OmnikInverterOptionsFlowHandler(OptionsFlow):
                 vol.Required(
                     CONF_SERIAL, default=self.config_entry.data.get(CONF_SERIAL)
                 )
-            ] = str
+            ] = int
 
         fields[
             vol.Optional(


### PR DESCRIPTION
This seems to have been a copy-paste error, as the type of a TCP serial must really be `int` and not `str` (https://github.com/robbinjanssen/home-assistant-omnik-inverter/issues/199#issuecomment-1545514318).

---

I may simply be misunderstanding all this code, but we do seem to repeat the Voluptuous name, optionality and type of fields in many places: is it intended to be written this way or could we store the layout in a single coherent global "const" field?
