### PR TITLE
Change log level of some logs to debug

### DIFF
--- a/custom_components/omnik_inverter/coordinator.py
+++ b/custom_components/omnik_inverter/coordinator.py
@@ -94,9 +94,9 @@ class OmnikInverterDataUpdateCoordinator(DataUpdateCoordinator):
             }
             return data
         except OmnikInverterAuthError as error:
-            _LOGGER.exception("Failed to authenticate with the Omnik")
+            _LOGGER.debug("Failed to authenticate with the Omnik", exc_info=True)
             raise ConfigEntryAuthFailed from error
 
         except OmnikInverterError as error:
-            _LOGGER.exception("Failed to connect to the Omnik")
+            _LOGGER.debug("Failed to connect to the Omnik", exc_info=True)
             raise UpdateFailed(error) from error


### PR DESCRIPTION
I had to analyze my HA logs for another issue and it was difficult due to the Omnik integration generating a lot of logging during the night.

I would suggest to change these logs level to debug to avoid polluting the logs when not needed. When needed for debugging one can easily enable debug logging for the integration to get them again.

I had this running for a couple of days and seems to work as intended.