### PR TITLE
Remove deprecated assignment of `OptionsFlow.config_entry`

### DIFF
--- a/custom_components/omnik_inverter/config_flow.py
+++ b/custom_components/omnik_inverter/config_flow.py
@@ -286,7 +286,7 @@ class OmnikInverterOptionsFlowHandler(OptionsFlow):
         """
         errors = {}
 
-        source_type = config_entry.data[CONF_SOURCE_TYPE]
+        source_type = self.config_entry.data[CONF_SOURCE_TYPE]
 
         if user_input is not None:
             try:


### PR DESCRIPTION
Fixes https://github.com/robbinjanssen/home-assistant-omnik-inverter/issues/402

After (or supposedly since) HASS 2025.12, the setter for `OptionsFlow.config_entry` was deleted in https://github.com/home-assistant/core/pull/155958, breaking startup of this integration.

TODO: I'm not exactly confident on what the existing state logic means, if we could remove it from `__init__()` entirely and pull `data` out of `self.config_entry.data` using the  existing getter instead?